### PR TITLE
[Fix] 마이페이지 빌드 오류 해결

### DIFF
--- a/src/pages/sinitto/mypage/components/profile-box/SinittoProfileBox.tsx
+++ b/src/pages/sinitto/mypage/components/profile-box/SinittoProfileBox.tsx
@@ -30,9 +30,9 @@ const SinittoProfileBox = ({ isEditing, setIsEditing }: Props) => {
     const modifiedSinittoInfo = {
       name: name,
       phoneNumber: phoneNumber,
-      email: data?.email as string,
-      accountNumber: data?.accountNumber as string,
-      bankName: data?.bankName as string,
+      email: String(data?.email),
+      accountNumber: String(data?.accountNumber),
+      bankName: String(data?.bankName),
     };
     modifySinittoInfoMutation.mutate(modifiedSinittoInfo, {
       onSuccess: () => {

--- a/src/pages/sinitto/mypage/components/profile-box/SinittoProfileBox.tsx
+++ b/src/pages/sinitto/mypage/components/profile-box/SinittoProfileBox.tsx
@@ -27,15 +27,19 @@ const SinittoProfileBox = ({ isEditing, setIsEditing }: Props) => {
   }, [isEditing, data]);
 
   const handleSaveClick = () => {
-    modifySinittoInfoMutation.mutate(
-      { ...data, name, phoneNumber },
-      {
-        onSuccess: () => {
-          setIsEditing(false);
-          refetch();
-        },
-      }
-    );
+    const modifiedSinittoInfo = {
+      name: name,
+      phoneNumber: phoneNumber,
+      email: data?.email as string,
+      accountNumber: data?.accountNumber as string,
+      bankName: data?.bankName as string,
+    };
+    modifySinittoInfoMutation.mutate(modifiedSinittoInfo, {
+      onSuccess: () => {
+        setIsEditing(false);
+        refetch();
+      },
+    });
   };
 
   if (isLoading) return <div>로딩 중...</div>;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #82 

## 📝 작업 내용

[Fix] 마이페이지 빌드 오류 해결

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)

### 시니또 본인 정보 수정 API 호출 과정에서 타입 오류 해결
- 시니또 마이페이지에서 본인 정보를 수정할 때, 이름(name), 전화번호(phoneNumber) 만 수정하도록 되어있는데 본인 정보 수정 API 요청 형식에는 email, bankName, accoutNumber 도 포함되어있어, 스프레드 문법 (...data)으로 수정되지 않는 데이터는 그대로 담아 보내는 과정에서 undefined 로 들어오는 경우에 대해 오류가 나타나고 있었습니다. 여러 방법 중에 결국 시니또 마이페이지에서 본인 정보를 수정을 하기 위해서는 email, bankName, accountNumber 는 반드시 가지고 있어야 하는 데이터이기 때문에 (회원가입 시 필요), 타입 단언을 통해 해결했습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 

## ⏰ 현재 버그

## ✏ Git Close

> close #82 
